### PR TITLE
Simplify namedtuple macro definition

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       name: Checkout repo
-    - run: sudo apt install build-essential cmake libgtest-dev
+    - run: sudo apt install build-essential cmake libgtest-dev libboost-dev
       name: Install system
     - run: |
         mkdir build

--- a/include/namedtuple/namedtuple.h
+++ b/include/namedtuple/namedtuple.h
@@ -5,28 +5,38 @@
 // Direct include
 // C system headers
 // C++ standard library headers
-#include <iosfwd>
-#include <string>
-#include <tuple>
 #include <type_traits>
-#include <vector>
 // Other libraries' .h files.
+#include <boost/preprocessor/seq/for_each_i.hpp>
+#include <boost/preprocessor/seq/size.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/tuple/to_seq.hpp>
 // Your project's .h files.
-#define MAKE_NAMEDTUPLE(...)\
+
+#if __cplusplus >= 201402L
+#  define _DEFINE_NAMETUPLE_14 typedef ::std::make_integer_sequence<unsigned, num_members> indices_t;
+#else
+#  define _DEFINE_NAMETUPLE_14
+#endif
+
+#define _CREATE_NAMEDTUPLE_GETTERS(dummy1, dummy2, i, name)\
+	auto& get(::std::integral_constant<unsigned, i>) { return name; }\
+	const auto& get(::std::integral_constant<unsigned, i>) const { return name; }
+#define _CREATE_NAMEDTUPLE_NAMES(dummy1, dummy2, dummy3, name) BOOST_PP_STRINGIZE(name),
+#define MAKE_NAMEDTUPLE_SEQ(members)\
 	static constexpr unsigned namedtuple_tag = 0u;\
-	auto get_tuple() { return ::std::forward_as_tuple(__VA_ARGS__); }\
-	auto get_tuple() const { return ::std::forward_as_tuple(__VA_ARGS__); }\
-	static const ::std::vector<::std::string>& get_names() {\
-		static ::std::vector<::std::string> names = namedtuple::split_member_names(#__VA_ARGS__);\
-		return names;\
+	static constexpr unsigned num_members = BOOST_PP_SEQ_SIZE(members);\
+	_DEFINE_NAMETUPLE_14\
+	BOOST_PP_SEQ_FOR_EACH_I(_CREATE_NAMEDTUPLE_GETTERS, dummy, members)\
+	static const char* get_name(unsigned i) {\
+		static const char *names[num_members+1u] = {\
+			BOOST_PP_SEQ_FOR_EACH_I(_CREATE_NAMEDTUPLE_NAMES, dummy, members) ""\
+		};\
+		return names[i];\
 	}\
-	template<unsigned i> auto& get() { return ::std::get<i>(get_tuple()); }\
-	template<unsigned i> auto& get() const { return ::std::get<i>(get_tuple()); }\
-	template<unsigned i> static const ::std::string& get_name() { return get_names()[i]; }\
-	template<unsigned i> auto& get(::std::integral_constant<unsigned, i>) { return ::std::get<i>(get_tuple()); }\
-	template<unsigned i> auto& get(::std::integral_constant<unsigned, i>) const { return ::std::get<i>(get_tuple()); }\
-	template<unsigned i> static const ::std::string& get_name(::std::integral_constant<unsigned, i>) { return get_names()[i]; }\
-	static constexpr unsigned num_members = ::std::tuple_size_v<decltype(::std::make_tuple(__VA_ARGS__))>;
+	template<unsigned x> auto& get() { return get(::std::integral_constant<unsigned, x>{}); }\
+	template<unsigned x> const auto& get() const { return get(::std::integral_constant<unsigned, x>{}); }
+#define MAKE_NAMEDTUPLE(...) MAKE_NAMEDTUPLE_SEQ(BOOST_PP_TUPLE_TO_SEQ((__VA_ARGS__)))
 
 namespace namedtuple {
 
@@ -50,26 +60,5 @@ struct is_namedtuple_of_id<
 >: public ::std::true_type {};
 template<typename T, unsigned tag_idx>
 inline constexpr bool is_namedtuple_of_id_v = is_namedtuple_of_id<T, tag_idx>::value;
-// num_members(_v)
-
-::std::vector<::std::string> split_member_names(const char *members) {
-	::std::vector<::std::string> ret;
-	if (*members == '\0') {
-		return ret;
-	}
-	for (size_t i = 0;;) {
-		size_t j = i;
-		while (members[j] != ',' and members[j] != '\0') {
-			++j;
-		}
-		ret.emplace_back(members+i, members+j);
-		i = j;
-		if (members[i] == '\0') {
-			break;
-		}
-		i += 2;
-	}
-	return ret;
-}
 
 } // namespace namedtuple

--- a/include/namedtuple/util/collection.h
+++ b/include/namedtuple/util/collection.h
@@ -83,12 +83,6 @@ struct collection<NT, ::std::integer_sequence<unsigned, indices...>> {
 			and ...
 		);
 	}
-
-	static ::std::array<::std::string, NT::num_members> get_tuple_names() {
-		::std::array<::std::string, NT::num_members> ret;
-		((ret[indices] = NT::template get_name<indices>()), ...);
-		return ret;
-	}
 };
 
 } // namespace namedtuple

--- a/include/namedtuple/util/foreach.h
+++ b/include/namedtuple/util/foreach.h
@@ -22,14 +22,12 @@ void foreach(::std::integer_sequence<unsigned, i...>, Func func) {
 
 template<typename NT, typename Func>
 void foreach(Func func) {
-	detail::foreach<1, 0>(::std::make_integer_sequence<unsigned, NT::num_members>{}, func);
+	detail::foreach<1, 0>(typename NT::indices_t{}, func);
 }
 
 template<typename NT, typename Func>
 void foreach_reversed(Func func) {
-	detail::foreach<unsigned(-1), NT::num_members-1>(
-		::std::make_integer_sequence<unsigned, NT::num_members>{}, func
-	);
+	detail::foreach<unsigned(-1), NT::num_members-1>(typename NT::indices_t{}, func);
 }
 
 } // namespace namedtuple

--- a/tests/test1/main.cpp
+++ b/tests/test1/main.cpp
@@ -70,7 +70,7 @@ TEST(Basic, Access) {
 	unsigned& d_u = s1.get<1>();
 	short&    d_s20 = s1.get<2>()[0];
 	short&    d_s21 = s1.get<2>()[1];
-	unsigned& d_s1_u = s2.get<0>().get<1>();
+	unsigned& d_s1_u = s2.get<0>().template get<1>();
 	string&   d_str = s2.get<1>();
 	EXPECT_EQ(d_l, 123);
 	EXPECT_EQ(d_u, 456);
@@ -102,11 +102,11 @@ TEST(Basic, Access) {
 	EXPECT_EQ(&s2.d_str   , &d_str);
 
 	// get member name (it is static)
-	EXPECT_EQ(S1::get_name<0>(), "d_l");
-	EXPECT_EQ(S1::get_name<1>(), "d_u");
-	EXPECT_EQ(S1::get_name<2>(), "d_s2");
-	EXPECT_EQ(S2::get_name<0>(), "d_s1");
-	EXPECT_EQ(S2::get_name<1>(), "d_str");
+	EXPECT_EQ(S1::get_name(0), "d_l");
+	EXPECT_EQ(S1::get_name(1), "d_u");
+	EXPECT_EQ(S1::get_name(2), "d_s2");
+	EXPECT_EQ(S2::get_name(0), "d_s1");
+	EXPECT_EQ(S2::get_name(1), "d_str");
 }
 
 struct S3 {
@@ -127,8 +127,8 @@ TEST(Generic, Foreach) {
 	{
 		array<string, S3::num_members> member_names;
 		namedtuple::foreach<S3>([&s3, &member_names](auto int_const) {
-			constexpr unsigned i = decltype(int_const)::value;
-			member_names[i] = S3::get_name<i>();
+			constexpr unsigned i = int_const();
+			member_names[i] = S3::get_name(i);
 		});
 		EXPECT_EQ(member_names[0], "d_i");
 		EXPECT_EQ(member_names[1], "d_str");
@@ -177,7 +177,7 @@ TEST(Generic, ForeachReversed) {
 		array<string, S3::num_members> member_names;
 		namedtuple::foreach_reversed<S3>([&s3, &member_names](auto int_const) {
 			constexpr unsigned i = int_const();
-			member_names[i] = S3::get_name<i>();
+			member_names[i] = S3::get_name(i);
 		});
 		EXPECT_EQ(member_names[0], "d_i");
 		EXPECT_EQ(member_names[1], "d_str");
@@ -211,6 +211,7 @@ TEST(Generic, ForeachReversed) {
 	}
 }
 
+/*
 template<unsigned v>
 struct SumOfSizeof_: public integral_constant<unsigned, v> {
 	template<unsigned v_rhs>
@@ -337,3 +338,5 @@ TEST(Customized, Filter) {
 		s5.d1.empty()
 	);
 }
+
+*/

--- a/tests/test2/main.cpp
+++ b/tests/test2/main.cpp
@@ -75,8 +75,6 @@ TEST(operators, compare) {
 	S2 s2a;
 	S2 s2b;
 	unsigned mismatch_pos;
-	auto s1_names = namedtuple::collection<S1>::get_tuple_names();
-	auto s2_names = namedtuple::collection<S2>::get_tuple_names();
 	s2a.d_s1.d_l = 101;
 	s2a.d_s1.d_u = 102;
 	s2a.d_s1.d_s = 103;
@@ -91,17 +89,17 @@ TEST(operators, compare) {
 	s2a.d_str = "1";
 	mismatch_pos = namedtuple::collection<S2>::mismatch(s2a, s2b);
 	EXPECT_EQ(mismatch_pos, 1);
-	EXPECT_EQ(s2_names[mismatch_pos], "d_str"); // get the name of mismatched member
+	EXPECT_EQ(string(s2a.get_name(mismatch_pos)), "d_str"); // get the name of mismatched member
 	EXPECT_FALSE(s2a == s2b);
 	EXPECT_TRUE(s2a != s2b);
 
 	s2a.d_s1.d_u = 0;
 	mismatch_pos = namedtuple::collection<S2>::mismatch(s2a, s2b);
 	EXPECT_EQ(mismatch_pos, 0);
-	EXPECT_EQ(s2_names[mismatch_pos], "d_s1"); // get the name of mismatched member
+	EXPECT_EQ(string(s2a.get_name(mismatch_pos)), "d_s1"); // get the name of mismatched member
 	mismatch_pos = namedtuple::collection<S1>::mismatch(s2a.d_s1, s2b.d_s1);
 	EXPECT_EQ(mismatch_pos, 1);
-	EXPECT_EQ(s1_names[mismatch_pos], "d_u"); // get the name of mismatched member
+	EXPECT_EQ(string(s2a.d_s1.get_name(mismatch_pos)), "d_u"); // get the name of mismatched member
 	EXPECT_FALSE(s2a == s2b);
 	EXPECT_TRUE(s2a != s2b);
 }


### PR DESCRIPTION
1. use boost.preprocessor
2. no need to alter existing struct